### PR TITLE
feat(api): バッチ処理のリソース監視とメモリ解放を追加

### DIFF
--- a/app/api/v1/batch.py
+++ b/app/api/v1/batch.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 import asyncio as _asyncio
+import gc
 import logging
 from datetime import datetime as dt
 from typing import Any, Dict, List, Optional, cast
+
+try:
+    import psutil
+
+    PSUTIL_AVAILABLE = True
+except ImportError:
+    PSUTIL_AVAILABLE = False
 
 from fastapi import APIRouter, BackgroundTasks, Depends
 from fastapi import status as http_status
@@ -33,6 +41,34 @@ from app.utils.database import get_session_maker
 router = APIRouter(tags=["batch"])
 
 logger = logging.getLogger(__name__)
+
+
+def _log_memory_usage(context: str) -> None:
+    """メモリ使用状況をログ出力するヘルパー関数.
+
+    Args:
+        context (str): ログ出力時のコンテキスト説明
+
+    Returns:
+        None
+    """
+    if not PSUTIL_AVAILABLE:
+        return
+
+    try:
+        process = psutil.Process()
+        memory_info = process.memory_info()
+        memory_mb = memory_info.rss / 1024 / 1024
+        cpu_percent = process.cpu_percent(interval=0.1)
+
+        logger.info(
+            "[Resource Monitor] %s - Memory: %.2f MB, CPU: %.2f%%",
+            context,
+            memory_mb,
+            cpu_percent,
+        )
+    except Exception:
+        logger.exception("Failed to log memory usage")
 
 
 async def _commit_with_rollback(session, context: str, job_id: int) -> None:
@@ -170,6 +206,11 @@ async def _process_chunk_multi(
             success_inc += len(payloads)
         except Exception:
             failed_inc += len(payloads)
+
+    # チャンク処理後のリソース解放
+    del results
+    del payloads
+    gc.collect()
 
     return success_inc, failed_inc, errors
 
@@ -668,6 +709,9 @@ async def process_jpx_all_multi_sequence(
     timeframes = ["1d", "1m", "1h"]
     results: List[Dict[str, Any]] = []
 
+    # バッチ処理開始時のリソース状況
+    _log_memory_usage(f"Batch job {job_id} started")
+
     async with session_maker() as session:
         repo = BatchExecutionRepository(session)
         await repo.update_status(job_id, "running")
@@ -690,6 +734,11 @@ async def process_jpx_all_multi_sequence(
 
         try:
             for timeframe in timeframes:
+                # タイムフレーム処理前のリソース状況
+                _log_memory_usage(
+                    f"Before timeframe {timeframe} for job {job_id}"
+                )
+
                 result = await _execute_single_timeframe(
                     job_id, timeframe, batch_size, service
                 )
@@ -703,6 +752,24 @@ async def process_jpx_all_multi_sequence(
                         job_id,
                     )
 
+                # タイムフレーム処理後のリソース解放
+                logger.info(
+                    "Releasing resources after timeframe %s for job %s",
+                    timeframe,
+                    job_id,
+                )
+                # 不要な変数を明示的に削除
+                del result
+                # ガベージコレクションを実行
+                gc.collect()
+                # イベントループに制御を返す
+                await _asyncio.sleep(0.1)
+
+                # リソース解放後の状況を確認
+                _log_memory_usage(
+                    f"After timeframe {timeframe} cleanup for job {job_id}"
+                )
+
             overall_success = sum(r.get("success_count", 0) for r in results)
             overall_failed = sum(r.get("failed_count", 0) for r in results)
 
@@ -712,6 +779,9 @@ async def process_jpx_all_multi_sequence(
                 failed_count=overall_failed,
             )
             await _commit_with_rollback(session, "mark_completed", job_id)
+
+            # バッチ処理完了時のリソース状況
+            _log_memory_usage(f"Batch job {job_id} completed successfully")
 
         except Exception:
             logger.exception(
@@ -753,6 +823,9 @@ async def _execute_single_timeframe(
         "finished_at": None,
     }
 
+    # タイムフレーム処理開始時のリソース状況
+    _log_memory_usage(f"Timeframe {timeframe} started for job {job_id}")
+
     try:
         if service.stock_master_service is None:
             raise ServiceError(message="StockMasterService is required")
@@ -783,6 +856,10 @@ async def _execute_single_timeframe(
                 success += s_inc
                 failed += f_inc
 
+                # チャンク処理ごとにメモリ解放
+                del chunk
+                del _errs
+
                 if _sync_progress_cb is not None:
                     try:
                         _sync_progress_cb(
@@ -806,6 +883,9 @@ async def _execute_single_timeframe(
                 except Exception:
                     logger.exception("Failed to update batch progress")
 
+                # 定期的にイベントループに制御を返す
+                await _asyncio.sleep(0.01)
+
         await _await_pending_tasks(
             pending_tasks, "while awaiting pending progress tasks"
         )
@@ -813,6 +893,9 @@ async def _execute_single_timeframe(
         result["success_count"] = success
         result["failed_count"] = failed
         result["finished_at"] = dt.now().isoformat()
+
+        # タイムフレーム処理完了時のリソース状況
+        _log_memory_usage(f"Timeframe {timeframe} completed for job {job_id}")
 
         logger.info(
             "Completed timeframe %s for job %s: success=%s, failed=%s",

--- a/poetry.lock
+++ b/poetry.lock
@@ -2533,6 +2533,41 @@ files = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.1"
+description = "Cross-platform lib for process and system monitoring."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "psutil-7.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ba9f33bb525b14c3ea563b2fd521a84d2fa214ec59e3e6a2858f78d0844dd60d"},
+    {file = "psutil-7.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:81442dac7abfc2f4f4385ea9e12ddf5a796721c0f6133260687fec5c3780fa49"},
+    {file = "psutil-7.2.1-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea46c0d060491051d39f0d2cff4f98d5c72b288289f57a21556cc7d504db37fc"},
+    {file = "psutil-7.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35630d5af80d5d0d49cfc4d64c1c13838baf6717a13effb35869a5919b854cdf"},
+    {file = "psutil-7.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:923f8653416604e356073e6e0bccbe7c09990acef442def2f5640dd0faa9689f"},
+    {file = "psutil-7.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cfbe6b40ca48019a51827f20d830887b3107a74a79b01ceb8cc8de4ccb17b672"},
+    {file = "psutil-7.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:494c513ccc53225ae23eec7fe6e1482f1b8a44674241b54561f755a898650679"},
+    {file = "psutil-7.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fce5f92c22b00cdefd1645aa58ab4877a01679e901555067b1bd77039aa589f"},
+    {file = "psutil-7.2.1-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93f3f7b0bb07711b49626e7940d6fe52aa9940ad86e8f7e74842e73189712129"},
+    {file = "psutil-7.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d34d2ca888208eea2b5c68186841336a7f5e0b990edec929be909353a202768a"},
+    {file = "psutil-7.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2ceae842a78d1603753561132d5ad1b2f8a7979cb0c283f5b52fb4e6e14b1a79"},
+    {file = "psutil-7.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:08a2f175e48a898c8eb8eace45ce01777f4785bc744c90aa2cc7f2fa5462a266"},
+    {file = "psutil-7.2.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2e953fcfaedcfbc952b44744f22d16575d3aa78eb4f51ae74165b4e96e55f42"},
+    {file = "psutil-7.2.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:05cc68dbb8c174828624062e73078e7e35406f4ca2d0866c272c2410d8ef06d1"},
+    {file = "psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e38404ca2bb30ed7267a46c02f06ff842e92da3bb8c5bfdadbd35a5722314d8"},
+    {file = "psutil-7.2.1-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab2b98c9fc19f13f59628d94df5cc4cc4844bc572467d113a8b517d634e362c6"},
+    {file = "psutil-7.2.1-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f78baafb38436d5a128f837fab2d92c276dfb48af01a240b861ae02b2413ada8"},
+    {file = "psutil-7.2.1-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:99a4cd17a5fdd1f3d014396502daa70b5ec21bf4ffe38393e152f8e449757d67"},
+    {file = "psutil-7.2.1-cp37-abi3-win_amd64.whl", hash = "sha256:b1b0671619343aa71c20ff9767eced0483e4fc9e1f489d50923738caf6a03c17"},
+    {file = "psutil-7.2.1-cp37-abi3-win_arm64.whl", hash = "sha256:0d67c1822c355aa6f7314d92018fb4268a76668a536f133599b91edd48759442"},
+    {file = "psutil-7.2.1.tar.gz", hash = "sha256:f7583aec590485b43ca601dd9cea0dcd65bd7bb21d30ef4ddbf4ea6b5ed1bdd3"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel"]
+test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "setuptools"]
+
+[[package]]
 name = "psycopg"
 version = "3.2.13"
 description = "PostgreSQL database adapter for Python"
@@ -3744,4 +3779,4 @@ repair = ["scipy (>=1.6.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "ee82658d22149ff783483f75eacc871c0aa8709bfd38fd44b0e108aa016f5565"
+content-hash = "0777e10ed07a6f4a7265f212b1a2b6e9a6666d8e3822dbc7af33699d88f8657a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ python-multipart = ">=0.0.21"
 python-jose = {extras = ["cryptography"], version = "^3.5.0"}
 passlib = {extras = ["bcrypt"], version = "^1.7.4"}
 email-validator = "^2.3.0"
+psutil = "^7.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4"

--- a/tests/unit/api/v1/test_batch.py
+++ b/tests/unit/api/v1/test_batch.py
@@ -338,3 +338,305 @@ async def test_process_jpx_all_multi_sequence_handles_partial_failure(
     # Assert
     # 1dで10成功、1mで5失敗、1hで10成功 = 計20成功、5失敗
     assert fake_repo.mark_completed_args == (888, 20, 5)
+
+
+# ========================================
+# リソース管理機能のテスト
+# ========================================
+
+
+class TestLogMemoryUsage:
+    """_log_memory_usage関数のテスト."""
+
+    def test_log_memory_usage_with_psutil(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch
+    ) -> None:
+        """psutilが利用可能な場合、メモリ使用量をログ出力すること."""
+        # Arrange
+        import logging
+        from unittest.mock import MagicMock
+
+        mock_psutil = MagicMock()
+        mock_process = MagicMock()
+        mock_memory_info = MagicMock()
+        mock_memory_info.rss = 1024 * 1024 * 100  # 100MB
+        mock_process.memory_info.return_value = mock_memory_info
+        mock_process.cpu_percent.return_value = 25.5
+        mock_psutil.Process.return_value = mock_process
+
+        monkeypatch.setattr(batch_module, "PSUTIL_AVAILABLE", True)
+        monkeypatch.setattr(batch_module, "psutil", mock_psutil)
+
+        # Act
+        with caplog.at_level(logging.INFO):
+            batch_module._log_memory_usage("Test context")
+
+        # Assert
+        assert "[Resource Monitor]" in caplog.text
+        assert "Test context" in caplog.text
+        assert "100.00 MB" in caplog.text
+        assert "25.50%" in caplog.text
+
+    def test_log_memory_usage_without_psutil(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch
+    ) -> None:
+        """psutilが利用不可能な場合、何もログ出力しないこと."""
+        # Arrange
+        monkeypatch.setattr(batch_module, "PSUTIL_AVAILABLE", False)
+
+        # Act
+        batch_module._log_memory_usage("Test context")
+
+        # Assert
+        assert "[Resource Monitor]" not in caplog.text
+
+    def test_log_memory_usage_handles_exception(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch
+    ) -> None:
+        """メモリ情報取得時の例外を適切に処理すること."""
+        # Arrange
+        from unittest.mock import MagicMock
+
+        mock_psutil = MagicMock()
+        mock_psutil.Process.side_effect = Exception("Test error")
+
+        monkeypatch.setattr(batch_module, "PSUTIL_AVAILABLE", True)
+        monkeypatch.setattr(batch_module, "psutil", mock_psutil)
+
+        # Act
+        batch_module._log_memory_usage("Test context")
+
+        # Assert
+        assert "Failed to log memory usage" in caplog.text
+
+
+class TestProcessChunkMultiResourceManagement:
+    """_process_chunk_multi関数のリソース管理テスト."""
+
+    @pytest.mark.asyncio
+    async def test_process_chunk_multi_releases_memory(
+        self, monkeypatch
+    ) -> None:
+        """チャンク処理後にメモリが解放されること."""
+        # Arrange
+        import gc
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_service = MagicMock()
+        mock_fetcher = AsyncMock()
+        mock_validator = MagicMock()
+        mock_converter = MagicMock()
+        mock_saver = AsyncMock()
+
+        mock_service.fetcher = mock_fetcher
+        mock_service.validator = mock_validator
+        mock_service.converter = mock_converter
+        mock_service.saver = mock_saver
+
+        # fetcherは空の結果を返す
+        mock_fetcher.fetch_batch.return_value = {}
+
+        chunk = ["7203.T", "9984.T"]
+        timeframe = "1d"
+
+        # gcモジュールをモック
+        with patch.object(gc, "collect") as mock_gc_collect:
+            # Act
+            success, failed, errors = await batch_module._process_chunk_multi(
+                chunk, mock_service, timeframe, {}
+            )
+
+            # Assert
+            # gc.collect()が呼ばれることを確認
+            mock_gc_collect.assert_called_once()
+
+        assert success == 0
+        assert failed == 0
+        assert errors == []
+
+
+class TestExecuteSingleTimeframeResourceManagement:
+    """_execute_single_timeframe関数のリソース管理テスト."""
+
+    @pytest.mark.asyncio
+    async def test_execute_single_timeframe_logs_memory(
+        self, monkeypatch
+    ) -> None:
+        """タイムフレーム処理の開始時と完了時にメモリ使用量をログ出力すること."""
+        # Arrange
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        job_id = 1
+        timeframe = "1d"
+        batch_size = 50
+
+        mock_service = MagicMock()
+        mock_stock_master_service = AsyncMock()
+        mock_stock_master_service.get_all_active_symbols.return_value = []
+        mock_service.stock_master_service = mock_stock_master_service
+        mock_service.batch_service = MagicMock()
+
+        # BatchExecutionContextをモック
+        mock_batch_context = AsyncMock()
+        mock_batch_context.__aenter__ = AsyncMock(
+            return_value=mock_batch_context
+        )
+        mock_batch_context.__aexit__ = AsyncMock(return_value=None)
+        mock_batch_context.update_progress = AsyncMock()
+
+        with patch(
+            "app.api.v1.batch.BatchExecutionContext",
+            return_value=mock_batch_context,
+        ), patch(
+            "app.api.v1.batch._make_progress_handlers"
+        ) as mock_handlers, patch(
+            "app.api.v1.batch._log_memory_usage"
+        ) as mock_log_memory:
+            mock_handlers.return_value = (set(), None, None)
+
+            # Act
+            result = await batch_module._execute_single_timeframe(
+                job_id, timeframe, batch_size, mock_service
+            )
+
+            # Assert
+            # 開始時と完了時のログ呼び出しを確認
+            assert mock_log_memory.call_count >= 2
+
+            calls = [str(call) for call in mock_log_memory.call_args_list]
+            assert any("started" in call for call in calls)
+            assert any("completed" in call for call in calls)
+
+            assert result["status"] == "completed"
+            assert result["timeframe"] == timeframe
+
+
+class TestProcessJpxAllMultiSequenceResourceManagement:
+    """process_jpx_all_multi_sequence関数のリソース管理テスト."""
+
+    @pytest.mark.asyncio
+    async def test_sequence_logs_memory_at_each_timeframe(
+        self, monkeypatch
+    ) -> None:
+        """各タイムフレーム処理前後でメモリ使用量をログ出力すること."""
+        # Arrange
+        import gc
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        job_id = 1
+        batch_size = 50
+        mock_service = MagicMock()
+
+        # セッションのモック
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.rollback = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session_maker = MagicMock()
+        mock_session_maker.return_value.return_value = mock_session
+
+        # リポジトリのモック
+        mock_repo = MagicMock()
+        mock_repo.update_status = AsyncMock()
+        mock_repo.mark_completed = AsyncMock()
+
+        monkeypatch.setattr(
+            batch_module, "get_session_maker", lambda: mock_session_maker
+        )
+
+        with patch(
+            "app.api.v1.batch.BatchExecutionRepository",
+            return_value=mock_repo,
+        ), patch(
+            "app.api.v1.batch._execute_single_timeframe"
+        ) as mock_execute_timeframe, patch(
+            "app.api.v1.batch._log_memory_usage"
+        ) as mock_log_memory, patch.object(
+            gc, "collect"
+        ):
+            # タイムフレーム処理のモック(成功ケース)
+            mock_execute_timeframe.return_value = {
+                "status": "completed",
+                "success_count": 10,
+                "failed_count": 0,
+            }
+
+            # Act
+            await batch_module.process_jpx_all_multi_sequence(
+                job_id, batch_size, mock_service
+            )
+
+            # Assert
+            # メモリログが複数回呼ばれていることを確認
+            # バッチ開始時、各タイムフレーム前後、完了時
+            assert mock_log_memory.call_count >= 7
+
+            # バッチ開始時のログ
+            calls = [str(call) for call in mock_log_memory.call_args_list]
+            assert any("started" in call for call in calls)
+            assert any("completed successfully" in call for call in calls)
+
+    @pytest.mark.asyncio
+    async def test_sequence_releases_resources_after_each_timeframe(
+        self, monkeypatch
+    ) -> None:
+        """各タイムフレーム処理後にリソースを解放すること."""
+        # Arrange
+        import gc
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        job_id = 1
+        batch_size = 50
+        mock_service = MagicMock()
+
+        # セッションのモック
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.rollback = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session_maker = MagicMock()
+        mock_session_maker.return_value.return_value = mock_session
+
+        # リポジトリのモック
+        mock_repo = MagicMock()
+        mock_repo.update_status = AsyncMock()
+        mock_repo.mark_completed = AsyncMock()
+
+        monkeypatch.setattr(
+            batch_module, "get_session_maker", lambda: mock_session_maker
+        )
+
+        with patch(
+            "app.api.v1.batch.BatchExecutionRepository",
+            return_value=mock_repo,
+        ), patch(
+            "app.api.v1.batch._execute_single_timeframe"
+        ) as mock_execute_timeframe:
+            # タイムフレーム処理のモック
+            mock_execute_timeframe.return_value = {
+                "status": "completed",
+                "success_count": 10,
+                "failed_count": 0,
+            }
+
+            # gc.collectとasyncio.sleepをモック
+            with patch.object(gc, "collect") as mock_gc_collect, patch(
+                "app.api.v1.batch._asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep:
+                # Act
+                await batch_module.process_jpx_all_multi_sequence(
+                    job_id, batch_size, mock_service
+                )
+
+                # Assert
+                # タイムフレームは3つ(1d, 1m, 1h)なので、
+                # gc.collect()が3回呼ばれること
+                assert mock_gc_collect.call_count == 3
+
+                # asyncio.sleep(0.1)が3回呼ばれること
+                assert mock_sleep.call_count == 3
+                mock_sleep.assert_called_with(0.1)


### PR DESCRIPTION
- バッチ処理の各段階でメモリCPU使用率をログ出力するヘルパー関数 _log_memory_usage を追加
- psutilをoptional依存として扱い、未インストール時はスキップ
- チャンク処理後やタイムフレーム間での明示的な変数削除と gc.collect(), イベントループに戻すための短い sleep を挿入
- 関連するテストを調整
- 依存メタデータ更新（pyproject.toml / poetry.lock）

Refs: #217