### PR TITLE
feat(repositories): EDINET貸借対照表リポジトリ追加

### DIFF
--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -10,6 +10,9 @@ from app.repositories.base import BaseRepository
 from app.repositories.batch_execution_repository import (
     BatchExecutionRepository,
 )
+from app.repositories.edinet_balance_sheet_repository import (  # noqa: F401
+    EdinetBalanceSheetRepository,
+)
 from app.repositories.stock_data_repository import (
     StockData1dRepository,
     StockData1hRepository,
@@ -38,3 +41,4 @@ __all__ = [
     "StockData1wkRepository",
     "StockData1moRepository",
 ]
+__all__.append("EdinetBalanceSheetRepository")

--- a/app/repositories/edinet_balance_sheet_repository.py
+++ b/app/repositories/edinet_balance_sheet_repository.py
@@ -1,0 +1,166 @@
+"""EDINET 貸借対照表用 Repository 実装.
+
+主に UPSERT を含むコアメソッドを提供します。
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any, List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.functions import count as sql_count
+
+from app.models.edinet_balance_sheet import EdinetBalanceSheet
+from app.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class EdinetBalanceSheetRepository(BaseRepository[EdinetBalanceSheet]):
+    """`edinet_balance_sheets` テーブル向けの Repository 実装.
+
+    提案された設計書に従い、UPSERT（ON CONFLICT DO UPDATE）を用いた
+    更新制御を行います。
+    """
+
+    def __init__(self, session: AsyncSession):
+        super().__init__(session, model=EdinetBalanceSheet)
+
+    async def find_latest_by_sec_code(
+        self, sec_code: str
+    ) -> Optional[EdinetBalanceSheet]:
+        stmt = (
+            select(self.model)
+            .where(self.model.sec_code == sec_code)
+            .order_by(
+                self.model.period_end_date.desc(),
+                self.model.submission_date.desc(),
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def find_by_period(
+        self, sec_code: str, period_end_date: date
+    ) -> Optional[EdinetBalanceSheet]:
+        result = await self.session.execute(
+            select(self.model).where(
+                self.model.sec_code == sec_code,
+                self.model.period_end_date == period_end_date,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def find_by_doc_id(
+        self, doc_id: str
+    ) -> Optional[EdinetBalanceSheet]:
+        result = await self.session.execute(
+            select(self.model).where(self.model.doc_id == doc_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert(self, data: dict) -> EdinetBalanceSheet:
+        """単一レコードの UPSERT を実行し、結果のレコードを返す.
+
+        UPSERT は `(sec_code, period_end_date)` を UNIQUE キーとし、
+        `submission_date` の比較で古いデータは上書きしない条件を追加します。
+        """
+        if not data:
+            raise ValueError("data is required for upsert")
+
+        table = self.model.__table__
+        insert_stmt = pg_insert(table).values(data)
+
+        update_dict: dict[str, Any] = {
+            c.name: getattr(insert_stmt.excluded, c.name)
+            for c in table.c
+            if c.name not in ("id", "created_at")
+        }
+
+        stmt = insert_stmt.on_conflict_do_update(
+            index_elements=["sec_code", "period_end_date"],
+            set_=update_dict,
+            where=(
+                insert_stmt.excluded.submission_date >= table.c.submission_date
+            ),
+        )
+
+        try:
+            await self.session.execute(stmt)
+            await self.session.flush()
+            # 更新後のレコードを返す（UPSERT の後は存在する想定）
+            res = await self.find_by_period(
+                data["sec_code"], data["period_end_date"]
+            )
+            if res is None:
+                raise RuntimeError("upsert succeeded but result not found")
+            return res
+        except SQLAlchemyError as e:
+            logger.exception("edinet upsert failed: %s", e)
+            raise
+
+    async def get_latest_by_sec_codes(
+        self, sec_codes: List[str]
+    ) -> List[EdinetBalanceSheet]:
+        if not sec_codes:
+            return []
+
+        # PostgreSQL の DISTINCT ON 相当を利用するため、distinct(self.model.sec_code)
+        # と order_by を組み合わせる。呼び出し側で sec_codes を限定して利用する想定。
+        stmt = (
+            select(self.model)
+            .where(self.model.sec_code.in_(sec_codes))
+            .distinct(self.model.sec_code)
+            .order_by(
+                self.model.sec_code,
+                self.model.period_end_date.desc(),
+                self.model.submission_date.desc(),
+            )
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def find_by_fiscal_year(
+        self, sec_code: str, fiscal_year: int
+    ) -> List[EdinetBalanceSheet]:
+        result = await self.session.execute(
+            select(self.model)
+            .where(
+                self.model.sec_code == sec_code,
+                self.model.fiscal_year == fiscal_year,
+            )
+            .order_by(self.model.period_end_date.desc())
+        )
+        return list(result.scalars().all())
+
+    async def find_by_date_range(
+        self, sec_code: str, start_date: date, end_date: date
+    ) -> List[EdinetBalanceSheet]:
+        result = await self.session.execute(
+            select(self.model)
+            .where(
+                self.model.sec_code == sec_code,
+                self.model.period_end_date >= start_date,
+                self.model.period_end_date <= end_date,
+            )
+            .order_by(self.model.period_end_date.desc())
+        )
+        return list(result.scalars().all())
+
+    async def count_by_sec_code(self, sec_code: str) -> int:
+        stmt = (
+            select(sql_count())
+            .select_from(self.model)
+            .where(self.model.sec_code == sec_code)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one()
+
+
+__all__ = ["EdinetBalanceSheetRepository"]

--- a/tests/unit/repositories/test_edinet_balance_sheet_repository.py
+++ b/tests/unit/repositories/test_edinet_balance_sheet_repository.py
@@ -1,0 +1,160 @@
+"""`EdinetBalanceSheetRepository` の単体テスト。
+
+非同期セッションをモック化して、DB に接続せずに振る舞いを検証する。
+"""
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.edinet_balance_sheet import EdinetBalanceSheet
+from app.repositories.edinet_balance_sheet_repository import (
+    EdinetBalanceSheetRepository,
+)
+
+
+@pytest.fixture
+def mock_session():
+    return AsyncMock(spec=AsyncSession)
+
+
+@pytest.fixture
+def repository(mock_session):
+    return EdinetBalanceSheetRepository(mock_session)
+
+
+def make_model(**kwargs):
+    return EdinetBalanceSheet(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_crud_basic_operations(repository, mock_session):
+    # create は BaseRepository 側で flush を呼ぶだけなので、session.flush をモック
+    mock_session.flush = AsyncMock()
+
+    data = {
+        "doc_id": "DOC1",
+        "sec_code": "7203",
+        "submission_date": date(2025, 12, 31),
+        "period_end_date": date(2025, 3, 31),
+        "fiscal_year": 2024,
+    }
+
+    created = await repository.create(data)
+
+    assert isinstance(created, EdinetBalanceSheet)
+    assert created.sec_code == "7203"
+    mock_session.add.assert_called_once()
+    mock_session.flush.assert_awaited_once()
+
+    # find_by_period / find_by_doc_id / find_latest_by_sec_code の振る舞い
+    expected = make_model(**data)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = expected
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    got = await repository.find_by_period("7203", date(2025, 3, 31))
+    assert got is expected
+
+    got2 = await repository.find_by_doc_id("DOC1")
+    assert got2 is expected
+
+    got3 = await repository.find_latest_by_sec_code("7203")
+    assert got3 is expected
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_when_newer_and_not_when_older(
+    repository, mock_session
+):
+    # シーケンス: upsert -> find_by_period の呼び出しが行われる
+
+    # ケース1: 新しい submission_date の場合（更新される）
+    input_data_new = {
+        "doc_id": "DOC_NEW",
+        "sec_code": "1001",
+        "submission_date": date(2026, 1, 10),
+        "period_end_date": date(2025, 12, 31),
+    }
+    new_model = make_model(**input_data_new)
+    # session.execute の最初の呼び出し(upsert)は特に返り値を利用しないためダミーを返し、
+    # 2回目(find_by_period)は期待モデルを返す
+    mock_result_upsert = MagicMock()
+    mock_result_find = MagicMock()
+    mock_result_find.scalar_one_or_none.return_value = new_model
+    mock_session.execute = AsyncMock(
+        side_effect=[mock_result_upsert, mock_result_find]
+    )
+    mock_session.flush = AsyncMock()
+
+    ret = await repository.upsert(input_data_new)
+    assert ret is new_model
+
+    # ケース2: 古い submission_date の場合（更新されず既存のレコードが返る）
+    input_data_old = {
+        "doc_id": "DOC_OLD",
+        "sec_code": "1001",
+        "submission_date": date(2020, 1, 1),
+        "period_end_date": date(2025, 12, 31),
+    }
+    existing_model = make_model(
+        **{
+            "doc_id": "DOC_EXIST",
+            "sec_code": "1001",
+            "submission_date": date(2025, 12, 31),
+            "period_end_date": date(2025, 12, 31),
+        }
+    )
+    # upsert の execute 呼び出し後に find_by_period が既存モデルを返す想定
+    mock_result_upsert2 = MagicMock()
+    mock_result_find2 = MagicMock()
+    mock_result_find2.scalar_one_or_none.return_value = existing_model
+    mock_session.execute = AsyncMock(
+        side_effect=[mock_result_upsert2, mock_result_find2]
+    )
+    mock_session.flush = AsyncMock()
+
+    ret2 = await repository.upsert(input_data_old)
+    assert ret2 is existing_model
+    assert ret2.submission_date == date(2025, 12, 31)
+
+
+@pytest.mark.asyncio
+async def test_get_latest_by_sec_codes_and_count(repository, mock_session):
+    # get_latest_by_sec_codes
+    models = [
+        make_model(
+            doc_id="A",
+            sec_code="1111",
+            submission_date=date(2025, 1, 1),
+            period_end_date=date(2024, 12, 31),
+        ),
+        make_model(
+            doc_id="B",
+            sec_code="2222",
+            submission_date=date(2025, 2, 1),
+            period_end_date=date(2024, 12, 31),
+        ),
+    ]
+
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = models
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    ret = await repository.get_latest_by_sec_codes(["1111", "2222"])
+    assert ret == models
+
+    # 空リストは空を返す
+    ret_empty = await repository.get_latest_by_sec_codes([])
+    assert ret_empty == []
+
+    # count_by_sec_code
+    mock_result_count = MagicMock()
+    mock_result_count.scalar_one.return_value = 5
+    mock_session.execute = AsyncMock(return_value=mock_result_count)
+    cnt = await repository.count_by_sec_code("1111")
+    assert cnt == 5


### PR DESCRIPTION
追加内容: - app/repositories/edinet_balance_sheet_repository.py を追加; - app/repositories/__init__.py を更新; - tests/unit/repositories/test_edinet_balance_sheet_repository.py を追加

目的: EDINETの貸借対照表データ取得をリポジトリ化するため

Refs: #266, #287, #288, #289